### PR TITLE
Update ClamAV service configuration and clean requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       DB_PASSWORD: detectish_password
       DB_HOST: mysql
       DB_PORT: 3306
+      CLAMAV_HOST: clamav
+      CLAMAV_PORT: 3310
 
   clamav:
     image: clamav/clamav:latest

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,4 +10,3 @@ asyncio
 pyspf
 dnspython
 dkimpy
-clamav-client


### PR DESCRIPTION
Remove the unused `clamav-client` from requirements and add ClamAV service configuration to the docker-compose file.