### PR TITLE
Change Docker restart policy to 'unless-stopped'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - detectish-network
     ports:
       - "6969:6969"
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./phishing_email_example:/app/phishing_email_example
     environment:
@@ -31,7 +31,9 @@ services:
       # start_period is the time to wait before starting health checks
 
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     container_name: detectish-backend
     depends_on:
       mysql:
@@ -44,7 +46,7 @@ services:
       - detectish-network
     ports:
       - "3000:3000"
-    restart: always
+    restart: unless-stopped
     environment:
       DB_NAME: detectish_db
       DB_USER: detectish_user
@@ -61,7 +63,9 @@ services:
       retries: 5
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     container_name: detectish-frontend
     depends_on:
       backend:
@@ -70,7 +74,7 @@ services:
       - detectish-network
     ports:
       - "80:80"
-    restart: always
+    restart: unless-stopped
     environment:
       # For production in Docker, API calls are proxied through Nginx
       VITE_API_URL: "/api"
@@ -95,7 +99,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped
 
   mysql:
     image: mysql:lts
@@ -116,7 +120,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped
 
 volumes:
   mysql-data:


### PR DESCRIPTION
Update the restart policy for all services in the docker-compose file to 'unless-stopped' for better control over container restarts.